### PR TITLE
Populate hidden inputs on pages served from cache

### DIFF
--- a/index.php
+++ b/index.php
@@ -99,6 +99,14 @@ foreach ($gravitypopulate as $key) {
     
 }
 
+// $_COOKIE will be empty if served from cache. This, along with some JavaScript, will take care of populating the values.
+add_filter( 'gform_field_content', function ( $content, $field, $value, $lead_id, $form_id ) use ($gravitypopulate) {
+    if (in_array(trim($field->label), $gravitypopulate) && in_array(trim($field->inputName), $gravitypopulate) && $field->type === 'hidden') {
+        $content = '<div data-gravity-populate="' . $field->label . '">' . $content . '</div>';
+    }
+    return $content;
+}, 10, 5 );
+
 function generate_Populate_admin_page()
 {    
     $msg = '';    

--- a/send-cookie.js
+++ b/send-cookie.js
@@ -13,3 +13,37 @@ if(url_current.includes("?") == 1){
         }
     });
 }
+
+// This will update the hidden inputs' values if page was served from cache and unable to access via PHP $_COOKIE
+(function ($) {
+
+    $(function() {
+        const wrappers = document.querySelectorAll('[data-gravity-populate]');
+        wrappers.forEach(wrapper => {
+            const fieldName = wrapper.dataset.gravityPopulate;
+            const input = wrapper.querySelector('input');
+            const cookieValue = getCookie(`STYXKEY_${fieldName}`);
+            // If input exists, currently has no value, and cookie with value is set - then update the input's value;
+            if (input && !input.value && null !== cookieValue) {
+                input.value = cookieValue;
+            }
+        });
+    });
+
+    function getCookie(cname) {
+        var name = cname + "=";
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for(var i = 0; i <ca.length; i++) {
+          var c = ca[i];
+          while (c.charAt(0) == ' ') {
+            c = c.substring(1);
+          }
+          if (c.indexOf(name) == 0) {
+            return c.substring(name.length, c.length);
+          }
+        }
+        return null;
+    }
+
+})(jQuery)


### PR DESCRIPTION
I noticed this was not working on a site hosted by WP Engine. The reason was that the $_COOKIE superglobal was always empty when not logged in to WordPress as an admin. This is because WP Engine is serving pages from cache, and $_COOKIE is not populated. See this article: https://wpengine.co.uk/support/cookies-and-php-sessions/

Without a matching $_COOKIE or $_POST param, the plugin was not populating the hidden input values on outputting the form. Therefore, when the form would submit, the prepopulated value would not be set.

I hooked into Gravity Forms to output a custom attribute for the hidden inputs. JavaScript will use these attributes to lookup cookie values client-side and update the values of the hidden inputs.

Please let me know if you have any questions or concerns!

Thanks!